### PR TITLE
[Chore] #58 - 소셜로그인 뷰 UI 수정

### DIFF
--- a/HealthFoodMe/HealthFoodMe/Presentation/Auth/SocialLoginScene/VC/SocialLoginVC.swift
+++ b/HealthFoodMe/HealthFoodMe/Presentation/Auth/SocialLoginScene/VC/SocialLoginVC.swift
@@ -41,15 +41,13 @@ class SocialLoginVC: UIViewController {
     
     private lazy var kakaoLoginButton: UIButton = {
        let button = UIButton()
-        button.setImage(ImageLiterals.Auth.kakaoLoginBtn, for: .normal)
-        
+        button.setBackgroundImage(ImageLiterals.Auth.kakaoLoginBtn, for: .normal)
         return button
     }()
     
     private lazy var appleLoginButton: UIButton = {
         let button = UIButton()
-        button.setImage(ImageLiterals.Auth.appleLoginBtn, for: .normal)
-        
+        button.setBackgroundImage(ImageLiterals.Auth.appleLoginBtn, for: .normal)
         return button
     }()
     
@@ -122,14 +120,17 @@ extension SocialLoginVC {
             make.centerX.equalToSuperview()
         }
         
-        kakaoLoginButton.snp.makeConstraints { make in
-            make.top.equalTo(subTitleLabel.snp.bottom).offset(249)
-            make.centerX.equalToSuperview()
+        let loginButtonWidth = UIScreen.main.bounds.width - 100
+        appleLoginButton.snp.makeConstraints { make in
+            make.bottom.equalTo(view.safeAreaLayoutGuide).inset(120)
+            make.leading.trailing.equalToSuperview().inset(50)
+            make.height.equalTo(loginButtonWidth * 41/275)
         }
         
-        appleLoginButton.snp.makeConstraints {make in
-            make.top.equalTo(kakaoLoginButton.snp.bottom).offset(10)
-            make.centerX.equalToSuperview()
+        kakaoLoginButton.snp.makeConstraints { make in
+            make.bottom.equalTo(appleLoginButton.snp.top).offset(-10)
+            make.leading.trailing.equalToSuperview().inset(50)
+            make.height.equalTo(loginButtonWidth * 41/275)
         }
     }
     

--- a/HealthFoodMe/HealthFoodMe/Presentation/Auth/SocialLoginScene/VC/SocialLoginVC.swift
+++ b/HealthFoodMe/HealthFoodMe/Presentation/Auth/SocialLoginScene/VC/SocialLoginVC.swift
@@ -22,6 +22,7 @@ class SocialLoginVC: UIViewController {
         lb.text = I18N.Auth.title
         lb.font = UIFont(name: AppFontName.GodoB, size: 58)
         lb.textColor = .mainRed
+        lb.textAlignment = .center
         
         return lb
     }()
@@ -31,13 +32,9 @@ class SocialLoginVC: UIViewController {
         let boldFont = UIFont(name: AppFontName.appleSDGothicNeoBold, size: 14)!
         lb.text = I18N.Auth.subTitle
         lb.font = UIFont(name: AppFontName.appleSDGothicNeoMedium, size: 14)
-        lb.textColor = .helfmeBlack
+        lb.textColor = .helfmeGray1
         lb.numberOfLines = 2
         lb.textAlignment = .center
-        lb.setAttributedText(targetFontList: ["샐러드": boldFont,
-                                              "일반식": boldFont],
-                             targetColorList: ["샐러드": .mainGreen,
-                                               "일반식": .mainRed])
 
         return lb
     }()
@@ -59,7 +56,6 @@ class SocialLoginVC: UIViewController {
     // MARK: - View Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
-
         setLayout()
         setAddTarget()
     }


### PR DESCRIPTION
## 🔥 *Pull requests*

⛳️ **작업한 브랜치**
- feature/#58

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 수정된 GUI에 맞게 소셜 로그인 뷰 수정

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 버튼크기를 버튼의 width값을 이용해 비율로 다시 크기 계산 해주었습니다!

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|소셜로그인 뷰|<img width = "296" src="https://user-images.githubusercontent.com/65678579/178794481-0abafbb8-2201-461b-806c-da475ae47934.png">
|소셜로그인 뷰 버튼 크기 수정|<img width = "296" src="https://user-images.githubusercontent.com/65678579/178816876-ecfad8bc-a4a2-4e0f-8b40-e31da1d22d7f.png">|


## 📟 관련 이슈
- Resolved: #58
