### PR TITLE
[Feat] 메뉴탭에 메뉴판 전체보기 추가

### DIFF
--- a/HealthFoodMe/HealthFoodMe.xcodeproj/project.pbxproj
+++ b/HealthFoodMe/HealthFoodMe.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		695758F4288545CC00E36789 /* CopingTabEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 695758F3288545CC00E36789 /* CopingTabEntity.swift */; };
 		695758F928857FDC00E36789 /* ReviewWriteEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 695758F828857FDC00E36789 /* ReviewWriteEntity.swift */; };
 		696DD00F28BF950A0011CCEE /* AllImageCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 696DD00E28BF950A0011CCEE /* AllImageCVC.swift */; };
+		696DD01128BFB93B0011CCEE /* ImageHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 696DD01028BFB93B0011CCEE /* ImageHeaderView.swift */; };
 		69A878F828BD06C5008D0D97 /* ImageCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69A878F728BD06C5008D0D97 /* ImageCVC.swift */; };
 		69D7074B2888062E00C2C278 /* ReviewDeleteEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69D7074A2888062E00C2C278 /* ReviewDeleteEntity.swift */; };
 		69D7074D28885B9900C2C278 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 69D7074C28885B9900C2C278 /* GoogleService-Info.plist */; };
@@ -300,6 +301,7 @@
 		695758F3288545CC00E36789 /* CopingTabEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopingTabEntity.swift; sourceTree = "<group>"; };
 		695758F828857FDC00E36789 /* ReviewWriteEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewWriteEntity.swift; sourceTree = "<group>"; };
 		696DD00E28BF950A0011CCEE /* AllImageCVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllImageCVC.swift; sourceTree = "<group>"; };
+		696DD01028BFB93B0011CCEE /* ImageHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageHeaderView.swift; sourceTree = "<group>"; };
 		69A878F728BD06C5008D0D97 /* ImageCVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCVC.swift; sourceTree = "<group>"; };
 		69D7074A2888062E00C2C278 /* ReviewDeleteEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDeleteEntity.swift; sourceTree = "<group>"; };
 		69D7074C28885B9900C2C278 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
@@ -816,6 +818,7 @@
 				69028BAF2874A60E00373984 /* HeaderView.swift */,
 				69028BA72874675800373984 /* MenuView.swift */,
 				69028BA9287467F100373984 /* MenuDetailView.swift */,
+				696DD01028BFB93B0011CCEE /* ImageHeaderView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -2288,6 +2291,7 @@
 				EBFAEB0D28856388009C569C /* LogEventType.swift in Sources */,
 				EBF66AFD287227F500DE0ED1 /* calculateTopInset.swift in Sources */,
 				EBF66ACF287227F500DE0ED1 /* Result+.swift in Sources */,
+				696DD01128BFB93B0011CCEE /* ImageHeaderView.swift in Sources */,
 				3BB0FCE3288705E200C3862C /* BlogReviewListEntity.swift in Sources */,
 				A93252C628808B82001EDF50 /* ReviewDeleteAlertView.swift in Sources */,
 				EBF66AD7287227F500DE0ED1 /* Presentable.swift in Sources */,

--- a/HealthFoodMe/HealthFoodMe.xcodeproj/project.pbxproj
+++ b/HealthFoodMe/HealthFoodMe.xcodeproj/project.pbxproj
@@ -61,6 +61,8 @@
 		695758EE28830E3F00E36789 /* Splash.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 695758ED28830E3F00E36789 /* Splash.storyboard */; };
 		695758F4288545CC00E36789 /* CopingTabEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 695758F3288545CC00E36789 /* CopingTabEntity.swift */; };
 		695758F928857FDC00E36789 /* ReviewWriteEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 695758F828857FDC00E36789 /* ReviewWriteEntity.swift */; };
+		696DD00F28BF950A0011CCEE /* AllImageCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 696DD00E28BF950A0011CCEE /* AllImageCVC.swift */; };
+		69A878F828BD06C5008D0D97 /* ImageCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69A878F728BD06C5008D0D97 /* ImageCVC.swift */; };
 		69D7074B2888062E00C2C278 /* ReviewDeleteEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69D7074A2888062E00C2C278 /* ReviewDeleteEntity.swift */; };
 		69D7074D28885B9900C2C278 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 69D7074C28885B9900C2C278 /* GoogleService-Info.plist */; };
 		69D7074F28888D6500C2C278 /* ReviewEditEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69D7074E28888D6500C2C278 /* ReviewEditEntity.swift */; };
@@ -297,6 +299,8 @@
 		695758ED28830E3F00E36789 /* Splash.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Splash.storyboard; sourceTree = "<group>"; };
 		695758F3288545CC00E36789 /* CopingTabEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopingTabEntity.swift; sourceTree = "<group>"; };
 		695758F828857FDC00E36789 /* ReviewWriteEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewWriteEntity.swift; sourceTree = "<group>"; };
+		696DD00E28BF950A0011CCEE /* AllImageCVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllImageCVC.swift; sourceTree = "<group>"; };
+		69A878F728BD06C5008D0D97 /* ImageCVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCVC.swift; sourceTree = "<group>"; };
 		69D7074A2888062E00C2C278 /* ReviewDeleteEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDeleteEntity.swift; sourceTree = "<group>"; };
 		69D7074C28885B9900C2C278 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		69D7074E28888D6500C2C278 /* ReviewEditEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewEditEntity.swift; sourceTree = "<group>"; };
@@ -792,6 +796,8 @@
 			isa = PBXGroup;
 			children = (
 				69028BA52874673600373984 /* MenuCellCVC.swift */,
+				69A878F728BD06C5008D0D97 /* ImageCVC.swift */,
+				696DD00E28BF950A0011CCEE /* AllImageCVC.swift */,
 			);
 			path = Cells;
 			sourceTree = "<group>";
@@ -2192,6 +2198,7 @@
 				EBFAEAFE28851C09009C569C /* UserManager.swift in Sources */,
 				FD72FC9D288346480092746F /* UserWithdrawlModel.swift in Sources */,
 				EBF66AFE287227F500DE0ED1 /* makeVibrate.swift in Sources */,
+				69A878F828BD06C5008D0D97 /* ImageCVC.swift in Sources */,
 				FDF2E1FC287EFC710007D4F9 /* StarRatingSlider.swift in Sources */,
 				695758DE28811E9D00E36789 /* Config.swift in Sources */,
 				EBD19262287DBC1800EA053E /* MapDetailSummaryView.swift in Sources */,
@@ -2255,6 +2262,7 @@
 				EBFAEB312885F2F7009C569C /* MyReviewRepository.swift in Sources */,
 				EBFAEB332885F2F7009C569C /* MyReviewVC.swift in Sources */,
 				A93252B1287F2AF9001EDF50 /* ScrapVC.swift in Sources */,
+				696DD00F28BF950A0011CCEE /* AllImageCVC.swift in Sources */,
 				EBF66AF5287227F500DE0ED1 /* Logger.swift in Sources */,
 				FD72FC9E288346480092746F /* UserWithdrawalVC.swift in Sources */,
 				EBFAEB412885F43E009C569C /* MyReviewCVC.swift in Sources */,
@@ -2509,7 +2517,7 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.healthFoodMe.release;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = healthFood_dev;
+				PROVISIONING_PROFILE_SPECIFIER = HealthFoodMe_Dev;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;

--- a/HealthFoodMe/HealthFoodMe/Global/Literals/BaseNotiList.swift
+++ b/HealthFoodMe/HealthFoodMe/Global/Literals/BaseNotiList.swift
@@ -14,6 +14,7 @@ enum BaseNotiList: String {
   case withdrawalButtonClicked
   case moveFromHamburgerBar
   case reviewPhotoClicked
+  case menuPhotoClicked
   
   static func makeNotiName(list: BaseNotiList) -> NSNotification.Name {
     return Notification.Name(String(describing: list))

--- a/HealthFoodMe/HealthFoodMe/Global/Literals/StringLiterals.swift
+++ b/HealthFoodMe/HealthFoodMe/Global/Literals/StringLiterals.swift
@@ -53,6 +53,7 @@ struct I18N {
             static let carbohydrate = "탄수화물"
             static let protein = "단백질"
             static let fats = "지방"
+            static let imageHeader = "메뉴 전체보기"
         }
         
         struct Review {

--- a/HealthFoodMe/HealthFoodMe/Presentation/Detail/MenuTabScene/Cells/AllImageCVC.swift
+++ b/HealthFoodMe/HealthFoodMe/Presentation/Detail/MenuTabScene/Cells/AllImageCVC.swift
@@ -13,6 +13,7 @@ class AllImageCVC: UICollectionViewCell, UICollectionViewRegisterable {
     // MARK: - Properties
     
     static var isFromNib = false
+    let imgURLList = ["123", "123", "123", "123"] // 테스트용
     
     // MARK: - UI Components
     lazy var menuImageCV: UICollectionView = {
@@ -64,7 +65,7 @@ extension AllImageCVC {
 extension AllImageCVC: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return 7 //임시로 넣어둔 값 (서버 붙일때 수정 예정)
+        return 4 //임시로 넣어둔 값 (서버 붙일때 수정 예정)
     }
         
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
@@ -85,12 +86,14 @@ extension AllImageCVC: UICollectionViewDelegateFlowLayout {
         return CGSize(width: cellWidth, height: cellHeight)
     }
     
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
-        return UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0) // 수정 필요
-    }
-    
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
         return 8
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        let imageSlideData = ImageSlideDataModel.init(clickedIndex: indexPath.row,
+                                                      imgURLs: imgURLList ?? [])
+        postObserverAction(.menuPhotoClicked,object: imageSlideData)
     }
 }
 

--- a/HealthFoodMe/HealthFoodMe/Presentation/Detail/MenuTabScene/Cells/AllImageCVC.swift
+++ b/HealthFoodMe/HealthFoodMe/Presentation/Detail/MenuTabScene/Cells/AllImageCVC.swift
@@ -1,0 +1,97 @@
+//
+//  AllImageCVC.swift
+//  HealthFoodMe
+//
+//  Created by 최영린 on 2022/08/31.
+//
+
+import UIKit
+import SnapKit
+
+class AllImageCVC: UICollectionViewCell, UICollectionViewRegisterable {
+    
+    // MARK: - Properties
+    
+    static var isFromNib = false
+    
+    // MARK: - UI Components
+    lazy var menuImageCV: UICollectionView = {
+        let layout = UICollectionViewFlowLayout()
+        layout.minimumLineSpacing = 0
+        layout.scrollDirection = .horizontal
+        layout.sectionInset = .zero
+        
+        let cv = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        cv.showsHorizontalScrollIndicator = false
+        cv.backgroundColor = .helfmeWhite
+        cv.bounces = false
+        return cv
+    }()
+    
+    // MARK: - Life Cycle Part
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setLayout()
+        setDelegate()
+        registerCell()
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Methods
+
+extension AllImageCVC {
+    private func setDelegate() {
+        menuImageCV.delegate = self
+        menuImageCV.dataSource = self
+    }
+    
+    private func registerCell() {
+        ImageCVC.register(target: menuImageCV)
+    }
+    
+    private func setLayout() {
+        contentView.addSubviews(menuImageCV)
+        menuImageCV.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+    }
+}
+
+extension AllImageCVC: UICollectionViewDataSource {
+    
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return 7 //임시로 넣어둔 값 (서버 붙일때 수정 예정)
+    }
+        
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let allImageCell = menuImageCV.dequeueReusableCell(withReuseIdentifier: ImageCVC.className, for: indexPath) as? ImageCVC
+        else { return UICollectionViewCell() }
+//        allImageCell.setData(menuData: MenuTabVC().menuData[indexPath.row])
+        return allImageCell
+    }
+}
+
+extension AllImageCVC: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        let width = UIScreen.main.bounds.width
+        
+        let cellWidth = width * (107/375)
+        let cellHeight = cellWidth * (107/107)
+        
+        return CGSize(width: cellWidth, height: cellHeight)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
+        return UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0) // 수정 필요
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+        return 8
+    }
+}
+
+

--- a/HealthFoodMe/HealthFoodMe/Presentation/Detail/MenuTabScene/Cells/ImageCVC.swift
+++ b/HealthFoodMe/HealthFoodMe/Presentation/Detail/MenuTabScene/Cells/ImageCVC.swift
@@ -1,0 +1,66 @@
+//
+//  AllMenuImageCVC.swift
+//  HealthFoodMe
+//
+//  Created by 최영린 on 2022/08/29.
+//
+
+import UIKit
+
+class ImageCVC: UICollectionViewCell, UICollectionViewRegisterable {
+    
+    // MARK: - Properties
+    
+    static var isFromNib = false
+    
+    // MARK: - UI Components
+    
+    lazy var photoImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFill
+        imageView.layer.masksToBounds = true
+        imageView.image = ImageLiterals.MenuTab.emptyCard
+        return imageView
+    }()
+    
+    // MARK: - Life Cycle Part
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setLayout()
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Methods
+
+extension ImageCVC {
+    func setImage(_ image: UIImage) {
+        photoImageView.image = image
+    }
+    
+    func setImageURL(_ url: String) {
+        let url = URL(string: url)
+        DispatchQueue.global().async {
+            let data = try? Data(contentsOf: url!)
+            DispatchQueue.main.async {
+                self.photoImageView.image = UIImage(data: data!)
+            }
+        }
+    }
+    
+    func setLayout() {
+        contentView.addSubviews(photoImageView)
+        let width = UIScreen.main.bounds.width
+    
+        photoImageView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+            make.width.height.equalTo(width * 107/375)
+
+        }
+        photoImageView.layer.cornerRadius = 8
+        photoImageView.layer.masksToBounds = true
+    }
+}

--- a/HealthFoodMe/HealthFoodMe/Presentation/Detail/MenuTabScene/VC/MenuTabVC.swift
+++ b/HealthFoodMe/HealthFoodMe/Presentation/Detail/MenuTabScene/VC/MenuTabVC.swift
@@ -22,6 +22,10 @@ enum TabMenuCase: Int {
 	case review = 2
 }
 
+enum SectionLayout: CaseIterable {
+	case menu, menuImage
+}
+
 final class MenuTabVC: UIViewController {
 	
 	// MARK: - Properties
@@ -42,7 +46,7 @@ final class MenuTabVC: UIViewController {
 	
 	// MARK: - UI Components
 	
-	private var headerView = HeaderView()
+//	private var headerView = HeaderView()
 	
 	private lazy var menuCV: UICollectionView = {
 		let layout = UICollectionViewFlowLayout()
@@ -82,7 +86,7 @@ extension MenuTabVC {
 	private func setDelegate() {
 		menuCV.delegate = self
 		menuCV.dataSource = self
-		headerView.delegate = self
+//		headerView.delegate = self
 	}
 	
 	private func setUI() {
@@ -99,6 +103,7 @@ extension MenuTabVC {
 	
 	private func registerCell() {
 		MenuCellCVC.register(target: menuCV)
+		AllImageCVC.register(target: menuCV)
 	}
 	
 	private func bindGesture() {
@@ -187,16 +192,30 @@ extension MenuTabVC: UICollectionViewDelegate {
 
 extension MenuTabVC: UICollectionViewDataSource {
 	
+	func numberOfSections(in collectionView: UICollectionView) -> Int {
+		return 2
+	}
+	
 	func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-		return menuData.count
+		let sectionType = SectionLayout.allCases[section]
+		let count : Int = sectionType == .menu ? menuData.count : 1
+		return count
 	}
 		
 	func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-		guard let cell = menuCV.dequeueReusableCell(withReuseIdentifier: MenuCellCVC.className, for: indexPath) as? MenuCellCVC
-		else { return UICollectionViewCell() }
-		cell.setData(menuData: menuData[indexPath.row])
-		cell.changeCustomView(isMenu: isMenu)
-		return cell
+		let sectionType = SectionLayout.allCases[indexPath.section]
+		switch sectionType{
+		case .menu:
+			guard let menuCell = menuCV.dequeueReusableCell(withReuseIdentifier: MenuCellCVC.className, for: indexPath) as? MenuCellCVC
+			else { return UICollectionViewCell() }
+			menuCell.setData(menuData: menuData[indexPath.row])
+			menuCell.changeCustomView(isMenu: isMenu)
+			return menuCell
+		case .menuImage:
+			guard let imageCell = menuCV.dequeueReusableCell(withReuseIdentifier: AllImageCVC.className, for: indexPath) as? AllImageCVC
+			else { return UICollectionViewCell() }
+			return imageCell
+		}
 	}
 }
 
@@ -211,7 +230,13 @@ extension MenuTabVC: UICollectionViewDelegateFlowLayout {
 	}
 	
 	func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
-		return UIEdgeInsets(top: 20, left: 20, bottom: 120, right: 20)
+		let sectionType = SectionLayout.allCases[section]
+		switch sectionType{
+		case .menu:
+			return UIEdgeInsets(top: 20, left: 20, bottom: 20, right: 20)
+		case .menuImage:
+			return UIEdgeInsets(top: 20, left: 20, bottom: 120, right: 20)
+		}
 	}
 	
 	func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {

--- a/HealthFoodMe/HealthFoodMe/Presentation/Detail/MenuTabScene/VC/MenuTabVC.swift
+++ b/HealthFoodMe/HealthFoodMe/Presentation/Detail/MenuTabScene/VC/MenuTabVC.swift
@@ -9,6 +9,7 @@ import UIKit
 
 import SnapKit
 import RxSwift
+import ImageSlideShowSwift
 
 protocol ScrollDeliveryDelegate: AnyObject {
 	func scrollStarted(velocity: CGFloat, scrollView: UIScrollView)
@@ -71,6 +72,7 @@ final class MenuTabVC: UIViewController {
 		registerCell()
 		addGesture()
 		bindGesture()
+		addObserver()
 	}
 }
 
@@ -139,6 +141,35 @@ extension MenuTabVC {
 		pickModel += notPickModel
 		
 		self.menuData = pickModel
+	}
+	
+	private func addObserver() {
+		addObserverAction(.menuPhotoClicked) { noti in
+			if let slideData = noti.object as? ImageSlideDataModel {
+				self.clickPhotos(index: slideData.clickedIndex, urls: slideData.imgURLs)
+			}
+		}
+	}
+	
+	func clickPhotos(index: Int,urls: [String]){
+		let images :[ImageSlideShowProtocol] = urls.enumerated().map { index,url in
+			
+			ImageForSlide(title: "\(index+1)/\(urls.count)", url: URL(string: url)!)
+		}
+		
+		ImageSlideShowViewController.presentFrom(self) { controller in
+			controller.navigationBarTintColor = .black
+			controller.navigationController?.navigationBar.backgroundColor = .black
+			controller.navigationController?.navigationBar.barTintColor = .black
+			controller.navigationController?.navigationBar.tintColor = .black
+			controller.navigationController?.navigationBar.setBackgroundImage(UIImage(), for: .default)
+			
+			controller.dismissOnPanGesture = true
+			controller.slides = images
+			controller.enableZoom = true
+			controller.initialIndex = index
+			controller.view.backgroundColor = .black
+		}
 	}
 }
 

--- a/HealthFoodMe/HealthFoodMe/Presentation/Detail/MenuTabScene/VC/MenuTabVC.swift
+++ b/HealthFoodMe/HealthFoodMe/Presentation/Detail/MenuTabScene/VC/MenuTabVC.swift
@@ -46,7 +46,7 @@ final class MenuTabVC: UIViewController {
 	
 	// MARK: - UI Components
 	
-//	private var headerView = HeaderView()
+	//	private var headerView = HeaderView()
 	
 	private lazy var menuCV: UICollectionView = {
 		let layout = UICollectionViewFlowLayout()
@@ -104,6 +104,8 @@ extension MenuTabVC {
 	private func registerCell() {
 		MenuCellCVC.register(target: menuCV)
 		AllImageCVC.register(target: menuCV)
+		menuCV.register(ImageHeaderView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: ImageHeaderView.identifier
+		)
 	}
 	
 	private func bindGesture() {
@@ -201,7 +203,15 @@ extension MenuTabVC: UICollectionViewDataSource {
 		let count : Int = sectionType == .menu ? menuData.count : 1
 		return count
 	}
-		
+	
+	func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
+		if kind == UICollectionView.elementKindSectionHeader {
+			let header = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: "ImageHeaderView", for: indexPath)
+			return header
+		}
+		return UICollectionReusableView()
+	}
+	
 	func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
 		let sectionType = SectionLayout.allCases[indexPath.section]
 		switch sectionType{
@@ -229,13 +239,23 @@ extension MenuTabVC: UICollectionViewDelegateFlowLayout {
 		return CGSize(width: cellWidth, height: cellHeight)
 	}
 	
+	func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
+		let sectionType = SectionLayout.allCases[section]
+		switch sectionType{
+		case .menu:
+			return CGSize(width: collectionView.frame.width, height: 0)
+		case .menuImage:
+			return CGSize(width: collectionView.frame.width, height: 34)
+		}
+	}
+	
 	func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
 		let sectionType = SectionLayout.allCases[section]
 		switch sectionType{
 		case .menu:
 			return UIEdgeInsets(top: 20, left: 20, bottom: 20, right: 20)
 		case .menuImage:
-			return UIEdgeInsets(top: 20, left: 20, bottom: 120, right: 20)
+			return UIEdgeInsets(top: 6, left: 20, bottom: 120, right: 20)
 		}
 	}
 	

--- a/HealthFoodMe/HealthFoodMe/Presentation/Detail/MenuTabScene/VC/MenuTabVC.swift
+++ b/HealthFoodMe/HealthFoodMe/Presentation/Detail/MenuTabScene/VC/MenuTabVC.swift
@@ -106,8 +106,7 @@ extension MenuTabVC {
 	private func registerCell() {
 		MenuCellCVC.register(target: menuCV)
 		AllImageCVC.register(target: menuCV)
-		menuCV.register(ImageHeaderView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: ImageHeaderView.identifier
-		)
+		menuCV.register(ImageHeaderView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: ImageHeaderView.className)
 	}
 	
 	private func bindGesture() {

--- a/HealthFoodMe/HealthFoodMe/Presentation/Detail/MenuTabScene/Views/ImageHeaderView.swift
+++ b/HealthFoodMe/HealthFoodMe/Presentation/Detail/MenuTabScene/Views/ImageHeaderView.swift
@@ -1,0 +1,50 @@
+//
+//  ImageHeaderView.swift
+//  HealthFoodMe
+//
+//  Created by 최영린 on 2022/09/01.
+//
+
+import UIKit
+import SnapKit
+
+class ImageHeaderView: UICollectionReusableView {
+
+    // MARK: - Properties
+    static let identifier = "ImageHeaderView"
+
+    // MARK: - UI Components
+    lazy var imageHeaderLabel: UILabel = {
+        let lb = UILabel()
+        lb.textColor = .helfmeBlack
+        lb.font = .NotoBold(size: 15)
+        lb.text =  I18N.Detail.Menu.imageHeader
+
+        return lb
+    }()
+    
+    // MARK: - View Life Cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Methods
+
+extension ImageHeaderView {
+    private func setLayout() {
+        self.addSubviews(imageHeaderLabel)
+        
+        imageHeaderLabel.snp.makeConstraints { make in
+            make.leading.equalToSuperview().offset(20)
+            make.centerY.equalToSuperview()
+            make.height.equalTo(22)
+        }
+    }
+}

--- a/HealthFoodMe/HealthFoodMe/Presentation/Detail/MenuTabScene/Views/ImageHeaderView.swift
+++ b/HealthFoodMe/HealthFoodMe/Presentation/Detail/MenuTabScene/Views/ImageHeaderView.swift
@@ -11,9 +11,9 @@ import SnapKit
 class ImageHeaderView: UICollectionReusableView {
 
     // MARK: - Properties
-    static let identifier = "ImageHeaderView"
-
+    
     // MARK: - UI Components
+    
     lazy var imageHeaderLabel: UILabel = {
         let lb = UILabel()
         lb.textColor = .helfmeBlack


### PR DESCRIPTION
## 🔥 *Pull requests*

⛳️ **작업한 브랜치**
- feature/#232

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
메뉴탭에서 메뉴판 전체보기 추가

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
메뉴판 이미지와 메뉴판 이미지 클릭 시 확대되어 보이는 이미지들은 임시로 넣어뒀습니다. 서버 붙일때 수정하겠습니다~!
그리고.. 
질문이 있습니다 ! 
컬렉션뷰 헤더를 지정할때 모든 섹션에 "메뉴 전체보기" 라는 헤더가 생겨서 헤더 사이즈 지정하는 부분에서 menu section부분의 높이를 0으로 지정해서  안보이게 해두었는데 다른 좋은 방법이 없을까요? 도저히 모르겠습니다 ㅎㅎ

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|메뉴 전체보기|<img src = "https://user-images.githubusercontent.com/75068759/187743039-d11015e6-1fb8-4e5e-8b1b-7134ce7fefc7.jpeg" width ="250">|

용량이슈로 gif가 안올라가네요..
https://user-images.githubusercontent.com/75068759/187742929-7014a662-537c-4910-a1ea-58fc989831c6.MP4

## 📟 관련 이슈
- Resolved: #232 
