### PR TITLE
[fix] 닉네임 수정 뷰에서 placeholder 누락된 부분 수정

### DIFF
--- a/HealthFoodMe/HealthFoodMe/Global/Literals/StringLiterals.swift
+++ b/HealthFoodMe/HealthFoodMe/Global/Literals/StringLiterals.swift
@@ -22,6 +22,7 @@ struct I18N {
       struct ChangeNickname {
         static let headerTitle = "프로필 편집"
         static let guideText = "변경할 닉네임을 설정해주세요"
+        static let placeholder = "닉네임을 설정해 주세요"
         static let conditionText = "* 특수문자, 이모티콘은 사용 불가합니다\n* 띄어쓰기 포함 최대 12글자"
         static let ctaButtonTitle = "수정 완료"
         static let formatErrMessage =  "닉네임 설정 기준에 적합하지 않습니다"

--- a/HealthFoodMe/HealthFoodMe/Presentation/Auth/NicknameChangeScene/VC/NicknameChangeVC.swift
+++ b/HealthFoodMe/HealthFoodMe/Presentation/Auth/NicknameChangeScene/VC/NicknameChangeVC.swift
@@ -67,6 +67,7 @@ final class NicknameChangeVC: UIViewController {
     textField.font = UIFont.NotoMedium(size: 16)
     textField.clearButtonMode = .whileEditing
     textField.autocorrectionType = .no
+    textField.placeholder = I18N.Auth.ChangeNickname.placeholder
     return textField
   }()
   


### PR DESCRIPTION
## 🔥 *Pull requests*

⛳️ **작업한 브랜치**
- feature/#257

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
닉네임 변경 화면에서 textfield의 placeholder 가 누락된 문제를 해결하였습니다.
