### PR TITLE
[Fix] #265 - fastlane match 오류 수정 + fastfile 명령어 추가

### DIFF
--- a/HealthFoodMe/HealthFoodMe.xcodeproj/project.pbxproj
+++ b/HealthFoodMe/HealthFoodMe.xcodeproj/project.pbxproj
@@ -2523,10 +2523,12 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = HealthFoodMe/HealthFoodMe.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 202209071;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = FY8N9XTH66;
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = FY8N9XTH66;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = HealthFoodMe/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "헬푸미";
@@ -2550,6 +2552,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.healthFoodMe.release;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match Development com.healthFoodMe.release";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match Development com.healthFoodMe.release";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -2564,9 +2567,11 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = HealthFoodMe/HealthFoodMe.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 202209071;
 				DEVELOPMENT_TEAM = FY8N9XTH66;
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = FY8N9XTH66;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = HealthFoodMe/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "헬푸미";
@@ -2590,6 +2595,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.healthFoodMe.release;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match Development com.healthFoodMe.release";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match Development com.healthFoodMe.release";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;

--- a/HealthFoodMe/Podfile.lock
+++ b/HealthFoodMe/Podfile.lock
@@ -106,17 +106,17 @@ PODS:
   - GoogleUtilities/UserDefaults (7.8.0):
     - GoogleUtilities/Logger
   - ImageSlideShowSwift (0.1.8)
-  - KakaoSDKAuth (2.11.1):
-    - KakaoSDKCommon (= 2.11.1)
-  - KakaoSDKCommon (2.11.1):
-    - KakaoSDKCommon/Common (= 2.11.1)
-    - KakaoSDKCommon/Network (= 2.11.1)
-  - KakaoSDKCommon/Common (2.11.1)
-  - KakaoSDKCommon/Network (2.11.1):
+  - KakaoSDKAuth (2.11.2):
+    - KakaoSDKCommon (= 2.11.2)
+  - KakaoSDKCommon (2.11.2):
+    - KakaoSDKCommon/Common (= 2.11.2)
+    - KakaoSDKCommon/Network (= 2.11.2)
+  - KakaoSDKCommon/Common (2.11.2)
+  - KakaoSDKCommon/Network (2.11.2):
     - Alamofire (~> 5.1)
-    - KakaoSDKCommon/Common (= 2.11.1)
-  - KakaoSDKUser (2.11.1):
-    - KakaoSDKAuth (= 2.11.1)
+    - KakaoSDKCommon/Common (= 2.11.2)
+  - KakaoSDKUser (2.11.2):
+    - KakaoSDKAuth (= 2.11.2)
   - Kingfisher (7.3.2)
   - lottie-ios (3.4.3)
   - nanopb (2.30909.0):
@@ -216,9 +216,9 @@ SPEC CHECKSUMS:
   GoogleDataTransport: 1c8145da7117bd68bbbed00cf304edb6a24de00f
   GoogleUtilities: 1d20a6ad97ef46f67bbdec158ce00563a671ebb7
   ImageSlideShowSwift: bd0d5150bb687a6c47bafa92d654fb85310d5317
-  KakaoSDKAuth: bb2dfa7be30daa8403c9cfc8001aa6fde7a5b779
-  KakaoSDKCommon: 555e1bb46595b842ded01cf7888cc17bbae4e113
-  KakaoSDKUser: 08c0a4f40bebdebdf948a9e3d0e44ed5c2754f99
+  KakaoSDKAuth: 98f90fb67b2c2015cc94066a4489d54bb2f2a68e
+  KakaoSDKCommon: 83fef177bcad9a8f9cb728f92e04a464882d3a82
+  KakaoSDKUser: bf7b02e23257199995cdd03d59feb716416d14d6
   Kingfisher: 0086ad83719761ba9b2cdaf6ef4d5b4878cbae23
   lottie-ios: 9ae750cdc7820fecbd3c2f0cfc493038208fcdc4
   nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431

--- a/HealthFoodMe/fastlane/Fastfile
+++ b/HealthFoodMe/fastlane/Fastfile
@@ -77,7 +77,7 @@ lane :release do
       method: "app-store",
       signingStyle: "manual"
     }
-    )
+  )
 
   # 8. 앱스토어 업로드 🎉
   deliver(
@@ -93,18 +93,6 @@ lane :release do
     )
 end
 
-# lane이 모두 완료된 뒤 호출됨
-after_all do |lane|
-  # 9. 배포 결과 슬랙 노티 🚨
-  slack_after_lane(
-    message: "",
-    payload: {
-      "Version" => lane_context[SharedValues::VERSION_NUMBER],
-      "Build number" => lane_context[SharedValues::BUILD_NUMBER],
-      "Date" => Time.new.to_s
-      }
-    )
-end
 
 # 에러 발생 시 호출 됨
 error do |lane, exception|
@@ -117,5 +105,23 @@ error do |lane, exception|
       "Error Info" => exception.message
       }
     )
+  end
 end
+
+# match 인증서 파일 생성 -> 관리자용
+
+platform :ios do
+  lane :matchByTeam do
+      match(git_branch: "master", type: "appstore", username: "ckrgkswnsgh@icloud.com")
+      match(git_branch: "master", type: "development", username: "ckrgkswnsgh@icloud.com")
+  end
+end
+
+# match 인증서 받아오기 -> 팀원용
+
+platform :ios do
+  lane :matchReadOnly do
+      match(git_branch: "master", type: "appstore", username: "ckrgkswnsgh@icloud.com", readonly: true)
+      match(git_branch: "master", type: "development", username: "ckrgkswnsgh@icloud.com", readonly: true)
+  end
 end

--- a/HealthFoodMe/fastlane/Matchfile
+++ b/HealthFoodMe/fastlane/Matchfile
@@ -1,11 +1,11 @@
-git_url("git@github.com:Health-Food-Me/fastlane-match-iOS.git")
+git_url("https://github.com/L-j-h-c/fastlane-match.git")
 
 storage_mode("git")
 
-type("appstore") # The default type, can be: appstore, adhoc, enterprise or development
+type("development") # The default type, can be: appstore, adhoc, enterprise or development
 
-# app_identifier(["tools.fastlane.app", "tools.fastlane.app2"])
-# username("user@fastlane.tools") # Your Apple Developer Portal username
+app_identifier(["com.healthFoodMe.release"])
+username("ckrgkswnsgh@icloud.com") # Your Apple Developer Portal username
 
 # For all available options run `fastlane match --help`
 # Remove the # in the beginning of the line to enable the other options

--- a/HealthFoodMe/fastlane/README.md
+++ b/HealthFoodMe/fastlane/README.md
@@ -39,6 +39,22 @@ Push a new beta build to TestFlight
 
 
 
+### ios matchByTeam
+
+```sh
+[bundle exec] fastlane ios matchByTeam
+```
+
+
+
+### ios matchReadOnly
+
+```sh
+[bundle exec] fastlane ios matchReadOnly
+```
+
+
+
 ----
 
 This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.


### PR DESCRIPTION
## 🔥 *Pull requests*

⛳️ **작업한 브랜치**
- feature/#265

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
fastlane match 인증서 세팅 다시했습니다...흑흑 오가 레포에 있는 곳이 아니라 제 개인 레포로 옮겼어요...
하나의 인증서로 여러 프로젝트에서 profile을 만들려면 공용 레포를 사용해야 하더라구요...

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
제가 드린 레포 초대장.. 수령해주시고

프로젝트 경로에서 아래 명령어 입력하면 인증서가 다시 받아집니다! (fastlane 폴더가 있어야해요)
```
fastlane matchReadOnly
```

## 📟 관련 이슈
- Resolved: #265 
