### PR TITLE
[Feat] #285 - 상세 페이지 전체 메뉴판 API 연결

### DIFF
--- a/HealthFoodMe/HealthFoodMe/Presentation/Detail/MainDetailScene/VC/MainDetailVC.swift
+++ b/HealthFoodMe/HealthFoodMe/Presentation/Detail/MainDetailScene/VC/MainDetailVC.swift
@@ -553,7 +553,7 @@ extension MainDetailVC {
                         self.restaurantName = data.restaurant.name
                         self.mainInfoTVC.isInitialReload = self.mainInfoInitialReload
                         self.mainInfoTVC.setData(data: data)
-                        self.menuTabVC.setData(data: data.menu)
+                        self.menuTabVC.setData(data: data.menu, restaurantMenuBoard: data.restaurant.menuBoard)
                         self.reviewTabVC.restaurantName = data.restaurant.name
                         self.restaurantName = data.restaurant.name
                         self.scrapButtonInstance.isSelected = data.restaurant.isScrap

--- a/HealthFoodMe/HealthFoodMe/Presentation/Detail/MenuTabScene/Cells/AllImageCVC.swift
+++ b/HealthFoodMe/HealthFoodMe/Presentation/Detail/MenuTabScene/Cells/AllImageCVC.swift
@@ -78,7 +78,6 @@ extension AllImageCVC: UICollectionViewDataSource {
         guard let allImageCell = menuImageCV.dequeueReusableCell(withReuseIdentifier: ImageCVC.className, for: indexPath) as? ImageCVC
         else { return UICollectionViewCell() }
         allImageCell.setData(menuBoard: imgURLList[indexPath.row])
-//        print(imgURLList[indexPath.row], "👀👀👀")
         return allImageCell
     }
 }

--- a/HealthFoodMe/HealthFoodMe/Presentation/Detail/MenuTabScene/Cells/AllImageCVC.swift
+++ b/HealthFoodMe/HealthFoodMe/Presentation/Detail/MenuTabScene/Cells/AllImageCVC.swift
@@ -13,7 +13,9 @@ class AllImageCVC: UICollectionViewCell, UICollectionViewRegisterable {
     // MARK: - Properties
     
     static var isFromNib = false
-    let imgURLList = ["123", "123", "123", "123"] // 테스트용
+    var imgURLList = [String]() {didSet {
+        menuImageCV.reloadData()
+    }}
     
     // MARK: - UI Components
     lazy var menuImageCV: UICollectionView = {
@@ -60,18 +62,23 @@ extension AllImageCVC {
             make.edges.equalToSuperview()
         }
     }
+    
+    func setData(menuBoardList: [String]) {
+        self.imgURLList = menuBoardList
+    }
 }
 
 extension AllImageCVC: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return 4 //임시로 넣어둔 값 (서버 붙일때 수정 예정)
+        return imgURLList.count
     }
         
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let allImageCell = menuImageCV.dequeueReusableCell(withReuseIdentifier: ImageCVC.className, for: indexPath) as? ImageCVC
         else { return UICollectionViewCell() }
-//        allImageCell.setData(menuData: MenuTabVC().menuData[indexPath.row])
+        allImageCell.setData(menuBoard: imgURLList[indexPath.row])
+//        print(imgURLList[indexPath.row], "👀👀👀")
         return allImageCell
     }
 }

--- a/HealthFoodMe/HealthFoodMe/Presentation/Detail/MenuTabScene/Cells/ImageCVC.swift
+++ b/HealthFoodMe/HealthFoodMe/Presentation/Detail/MenuTabScene/Cells/ImageCVC.swift
@@ -63,4 +63,8 @@ extension ImageCVC {
         photoImageView.layer.cornerRadius = 8
         photoImageView.layer.masksToBounds = true
     }
+    
+    func setData(menuBoard: String) {
+        photoImageView.setImage(with: menuBoard)
+    }
 }

--- a/HealthFoodMe/HealthFoodMe/Presentation/Detail/MenuTabScene/VC/MenuTabVC.swift
+++ b/HealthFoodMe/HealthFoodMe/Presentation/Detail/MenuTabScene/VC/MenuTabVC.swift
@@ -40,7 +40,13 @@ final class MenuTabVC: UIViewController {
 			}
 		}
 	}
-	var menuBoard: [String] = []
+	var menuBoard: [String] = [] {
+		didSet {
+			DispatchQueue.main.async {
+				self.menuCV.reloadData()
+			}
+		}
+	}
 	
 	let panGesture = UIPanGestureRecognizer()
 	weak var delegate: ScrollDeliveryDelegate?
@@ -230,7 +236,8 @@ extension MenuTabVC: UICollectionViewDelegate {
 extension MenuTabVC: UICollectionViewDataSource {
 	
 	func numberOfSections(in collectionView: UICollectionView) -> Int {
-		return 2
+		let count: Int = self.menuBoard.count == 0 ? 1 : 2
+		return count
 	}
 	
 	func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {

--- a/HealthFoodMe/HealthFoodMe/Presentation/Detail/MenuTabScene/VC/MenuTabVC.swift
+++ b/HealthFoodMe/HealthFoodMe/Presentation/Detail/MenuTabScene/VC/MenuTabVC.swift
@@ -259,6 +259,10 @@ extension MenuTabVC: UICollectionViewDataSource {
 		case .menuImage:
 			guard let imageCell = menuCV.dequeueReusableCell(withReuseIdentifier: AllImageCVC.className, for: indexPath) as? AllImageCVC
 			else { return UICollectionViewCell() }
+//			print(self.menuBoard, "❤️")
+			DispatchQueue.main.async {
+				imageCell.setData(menuBoardList: self.menuBoard)
+			}
 			return imageCell
 		}
 	}

--- a/HealthFoodMe/HealthFoodMe/Presentation/Detail/MenuTabScene/VC/MenuTabVC.swift
+++ b/HealthFoodMe/HealthFoodMe/Presentation/Detail/MenuTabScene/VC/MenuTabVC.swift
@@ -149,7 +149,6 @@ extension MenuTabVC {
 		
 		self.menuData = pickModel
 		self.menuBoard = restaurantMenuBoard
-//		print(menuBoard, "🐬")
 	}
 	
 	
@@ -266,7 +265,6 @@ extension MenuTabVC: UICollectionViewDataSource {
 		case .menuImage:
 			guard let imageCell = menuCV.dequeueReusableCell(withReuseIdentifier: AllImageCVC.className, for: indexPath) as? AllImageCVC
 			else { return UICollectionViewCell() }
-//			print(self.menuBoard, "❤️")
 			DispatchQueue.main.async {
 				imageCell.setData(menuBoardList: self.menuBoard)
 			}

--- a/HealthFoodMe/HealthFoodMe/Presentation/Detail/MenuTabScene/VC/MenuTabVC.swift
+++ b/HealthFoodMe/HealthFoodMe/Presentation/Detail/MenuTabScene/VC/MenuTabVC.swift
@@ -40,6 +40,8 @@ final class MenuTabVC: UIViewController {
 			}
 		}
 	}
+	var menuBoard: [String] = []
+	
 	let panGesture = UIPanGestureRecognizer()
 	weak var delegate: ScrollDeliveryDelegate?
 	var swipeDismissDelegate: SwipeDismissDelegate?
@@ -121,7 +123,7 @@ extension MenuTabVC {
 		menuCV.isScrollEnabled = false
 	}
 	
-	func setData(data: [Menu]) {
+	func setData(data: [Menu], restaurantMenuBoard: [String]) {
 		var models: [MenuDataModel] = []
 		data.forEach {
 			models.append($0.toDomain())
@@ -140,7 +142,10 @@ extension MenuTabVC {
 		pickModel += notPickModel
 		
 		self.menuData = pickModel
+		self.menuBoard = restaurantMenuBoard
+//		print(menuBoard, "🐬")
 	}
+	
 	
 	private func addObserver() {
 		addObserverAction(.menuPhotoClicked) { noti in

--- a/HealthFoodMe/HealthFoodMe/Presentation/Detail/MenuTabScene/ViewModel/MenuDataModel.swift
+++ b/HealthFoodMe/HealthFoodMe/Presentation/Detail/MenuTabScene/ViewModel/MenuDataModel.swift
@@ -19,7 +19,3 @@ struct MenuDataModel: Codable {
     let fat: Int?
     let per: String?
 }
-
-extension MenuDataModel {
-
-}


### PR DESCRIPTION
## 🔥 *Pull requests*

⛳️ **작업한 브랜치**
- feature/#285

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 상세 페이지에서 메뉴판 이미지 띄우기
- 메뉴판 이미지 유무에 따라 section 개수 분기처리

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 데이터가 안 뜨는 식당이 있었는데 데이터가 없어서 나오지 않았던 것 같습니다..!
- 메뉴판 이미지가 없을 때 컬렉션뷰 셀이 잘려서 보여 레이아웃 재조정이 필요할 것 같습니다.

|식당|로그|메뉴판 없을 때 레이아웃|
|:--:|:--:|:--:|
|<img src = "https://user-images.githubusercontent.com/65678579/192383307-ed95999f-1eff-418e-b108-b0d23d10a6fa.png" width ="250">|<img src = "https://user-images.githubusercontent.com/65678579/192383604-5675b53b-e9fc-4851-9d9d-8bc31ad06892.png" width="300">|<img src= "https://user-images.githubusercontent.com/65678579/192384354-da78091e-3154-4c19-b484-fd091fdfa311.png" width="250">|




## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|메뉴판 이미지|<img src = "https://user-images.githubusercontent.com/65678579/192384108-7d6c14b3-8f95-4535-b642-66aad9e7b3cf.png" width ="250">|


## 📟 관련 이슈
- Resolved: #285
