### PR TITLE
[Fix] #311 - 검색 카테고리 엠티뷰 필터링 추가

### DIFF
--- a/HealthFoodMe/HealthFoodMe/Presentation/Search/SearchScene/VC/SearchVC.swift
+++ b/HealthFoodMe/HealthFoodMe/Presentation/Search/SearchScene/VC/SearchVC.swift
@@ -358,7 +358,7 @@ extension SearchVC {
     }
     
     private func isSearchResult(fromRecent: Bool, isCategory: Bool) {
-        if searchList.isEmpty && !fromRecent {
+        if searchList.filter({ $0.isCategory == false }).count == 0 && !fromRecent {
             searchEmptyView.isHidden = false
         } else {
             searchEmptyView.isHidden = true


### PR DESCRIPTION
## 🔥 *Pull requests*

⛳️ **작업한 브랜치**
- feature/#311

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->

검색 카테고리 엠티뷰 필터링 추가했습니다.

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

기존에 자동검색어 list의 개수가 0일 때 emptyView를 호출하는 방식으로 구현했었는데
음식 카테고리가 추가되면서 카테고리가 있으면서 검색 결과가 없는 경우에 emptyView가 뜨지 않는 이슈가 있었습니다.
그래서 필터링을 통해 이슈 해결했습니다.

```Swift
if searchList.filter({ $0.isCategory == false }).count == 0 && !fromRecent {
            searchEmptyView.isHidden = false
}
```


## 📸 스크린샷
#### 문제 상황 (ex. "덮" 검색 시)

<img src = "https://user-images.githubusercontent.com/74968390/193190069-6a90747a-b553-41db-9afc-bd1da4a22472.PNG" width = "250">

|수정|전|후|
|:--:|:--:|:--:|
|검색 결과|<img src = "https://user-images.githubusercontent.com/74968390/193190063-7d17ed8f-1fa5-447b-a8b3-965b1bc3a47d.PNG" width ="250">|<img src = "https://user-images.githubusercontent.com/74968390/193190056-5ddb4b53-5fe2-4f5c-919c-c261b0f0a928.PNG" width ="250">|

## 📟 관련 이슈
- Resolved: #311
