### PR TITLE
[Feat] #224 - 강제 && 권장 업데이트 플로우 구현 / 네트워크 에러 팝업 플로우 구현 / 토큰 재발급 로직 구현

### DIFF
--- a/HealthFoodMe/HealthFoodMe.xcodeproj/project.pbxproj
+++ b/HealthFoodMe/HealthFoodMe.xcodeproj/project.pbxproj
@@ -104,6 +104,8 @@
 		A9E593CF2876C26900B0F8B5 /* Color.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A9E593CE2876C26900B0F8B5 /* Color.xcassets */; };
 		A9E593D1287818E900B0F8B5 /* SearchTVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E593D0287818E900B0F8B5 /* SearchTVC.swift */; };
 		EB033E84287B5BE300C48FB9 /* StarRatingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB033E83287B5BE300C48FB9 /* StarRatingView.swift */; };
+		EB1C254528E6DDE000C46B2F /* NSBundle+.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB1C254428E6DDE000C46B2F /* NSBundle+.swift */; };
+		EB1C254728E6E2E900C46B2F /* remote_config_defaults.plist in Resources */ = {isa = PBXBuildFile; fileRef = EB1C254628E6E2E900C46B2F /* remote_config_defaults.plist */; };
 		EB6A44C7287366DF00749582 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = EB6A44C6287366DF00749582 /* .swiftlint.yml */; };
 		EB6A44D128737CC400749582 /* MainDetailUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB6A44CB28737CC400749582 /* MainDetailUseCase.swift */; };
 		EB6A44D228737CC400749582 /* MainDetailRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB6A44CC28737CC400749582 /* MainDetailRepository.swift */; };
@@ -358,6 +360,8 @@
 		EB033E83287B5BE300C48FB9 /* StarRatingView.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = StarRatingView.swift; sourceTree = "<group>"; tabWidth = 4; };
 		EB085ED628716E1900361837 /* HealthFoodMe.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HealthFoodMe.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		EB085EE728716E1B00361837 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		EB1C254428E6DDE000C46B2F /* NSBundle+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSBundle+.swift"; sourceTree = "<group>"; };
+		EB1C254628E6E2E900C46B2F /* remote_config_defaults.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = remote_config_defaults.plist; sourceTree = "<group>"; };
 		EB6A44C6287366DF00749582 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = SOURCE_ROOT; };
 		EB6A44CB28737CC400749582 /* MainDetailUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainDetailUseCase.swift; sourceTree = "<group>"; };
 		EB6A44CC28737CC400749582 /* MainDetailRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainDetailRepository.swift; sourceTree = "<group>"; };
@@ -1104,6 +1108,7 @@
 				EBF66A90287227F500DE0ED1 /* Presentation */,
 				EBF66AA2287227F500DE0ED1 /* Utils */,
 				EB085EE728716E1B00361837 /* Info.plist */,
+				EB1C254628E6E2E900C46B2F /* remote_config_defaults.plist */,
 				69D7074C28885B9900C2C278 /* GoogleService-Info.plist */,
 				EB6A44C6287366DF00749582 /* .swiftlint.yml */,
 			);
@@ -1445,6 +1450,7 @@
 				EBF66A5E287227F500DE0ED1 /* Design */,
 				EBF66A51287227F500DE0ED1 /* UserDefaults+.swift */,
 				EBF66A61287227F500DE0ED1 /* Reactive+.swift */,
+				EB1C254428E6DDE000C46B2F /* NSBundle+.swift */,
 				EBF66A62287227F500DE0ED1 /* String+.swift */,
 				EBF66A67287227F500DE0ED1 /* Result+.swift */,
 			);
@@ -2100,6 +2106,7 @@
 			files = (
 				FDC46A25288326AC00F62D20 /* splash_iOS.json in Resources */,
 				EB6A44C7287366DF00749582 /* .swiftlint.yml in Resources */,
+				EB1C254728E6E2E900C46B2F /* remote_config_defaults.plist in Resources */,
 				3B0B25582876BBE400950539 /* NotoSansCJKkr-Bold.otf in Resources */,
 				3B0B25572876BBE400950539 /* Pretendard-Medium.otf in Resources */,
 				A9325280287DD272001EDF50 /* SearchResult.storyboard in Resources */,
@@ -2379,6 +2386,7 @@
 				EBD1925F287DBBFC00EA053E /* TagSummaryCVC.swift in Sources */,
 				A9525F712873E1750065EB1D /* SearchVC.swift in Sources */,
 				EB6A450C2873D6C500749582 /* DetailSummaryView.swift in Sources */,
+				EB1C254528E6DDE000C46B2F /* NSBundle+.swift in Sources */,
 				A93252AD287F09D0001EDF50 /* SearchEmptyView.swift in Sources */,
 				695758E02881228700E36789 /* CopingHeaderView.swift in Sources */,
 				3B9332A22888643200543683 /* MyReviewEmptyViewCVC.swift in Sources */,

--- a/HealthFoodMe/HealthFoodMe.xcodeproj/project.pbxproj
+++ b/HealthFoodMe/HealthFoodMe.xcodeproj/project.pbxproj
@@ -106,6 +106,7 @@
 		EB033E84287B5BE300C48FB9 /* StarRatingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB033E83287B5BE300C48FB9 /* StarRatingView.swift */; };
 		EB1C254528E6DDE000C46B2F /* NSBundle+.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB1C254428E6DDE000C46B2F /* NSBundle+.swift */; };
 		EB1C254728E6E2E900C46B2F /* remote_config_defaults.plist in Resources */ = {isa = PBXBuildFile; fileRef = EB1C254628E6E2E900C46B2F /* remote_config_defaults.plist */; };
+		EB1C254928E8197100C46B2F /* UIApplcation+.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB1C254828E8197100C46B2F /* UIApplcation+.swift */; };
 		EB6A44C7287366DF00749582 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = EB6A44C6287366DF00749582 /* .swiftlint.yml */; };
 		EB6A44D128737CC400749582 /* MainDetailUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB6A44CB28737CC400749582 /* MainDetailUseCase.swift */; };
 		EB6A44D228737CC400749582 /* MainDetailRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB6A44CC28737CC400749582 /* MainDetailRepository.swift */; };
@@ -362,6 +363,7 @@
 		EB085EE728716E1B00361837 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		EB1C254428E6DDE000C46B2F /* NSBundle+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSBundle+.swift"; sourceTree = "<group>"; };
 		EB1C254628E6E2E900C46B2F /* remote_config_defaults.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = remote_config_defaults.plist; sourceTree = "<group>"; };
+		EB1C254828E8197100C46B2F /* UIApplcation+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplcation+.swift"; sourceTree = "<group>"; };
 		EB6A44C6287366DF00749582 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = SOURCE_ROOT; };
 		EB6A44CB28737CC400749582 /* MainDetailUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainDetailUseCase.swift; sourceTree = "<group>"; };
 		EB6A44CC28737CC400749582 /* MainDetailRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainDetailRepository.swift; sourceTree = "<group>"; };
@@ -1471,6 +1473,7 @@
 				EBF66A5B287227F500DE0ED1 /* UITextField+.swift */,
 				EBF66A5C287227F500DE0ED1 /* UIImage+.swift */,
 				EBF66A5D287227F500DE0ED1 /* UITableView+.swift */,
+				EB1C254828E8197100C46B2F /* UIApplcation+.swift */,
 			);
 			path = UI;
 			sourceTree = "<group>";
@@ -2376,6 +2379,7 @@
 				695758E52881852F00E36789 /* CopingEmptyView.swift in Sources */,
 				FD72FCC028834AB60092746F /* MainMapNavigationController.swift in Sources */,
 				EBA8C14B2882A737009DBA49 /* AuthRouter.swift in Sources */,
+				EB1C254928E8197100C46B2F /* UIApplcation+.swift in Sources */,
 				69028BAC2874681700373984 /* MenuTabVC.swift in Sources */,
 				EBD19265287DC33900EA053E /* TagCVCFlowLayout.swift in Sources */,
 				695758C5287DF08800E36789 /* ListPhotoCVC.swift in Sources */,

--- a/HealthFoodMe/HealthFoodMe/Application/Manager/URLScheme/URLSchemeManager.swift
+++ b/HealthFoodMe/HealthFoodMe/Application/Manager/URLScheme/URLSchemeManager.swift
@@ -65,6 +65,12 @@ final class URLSchemeManager: NSObject {
             UIApplication.shared.open(url as URL, options: [:], completionHandler: nil)
         }
     }
+    
+    func loadHelfMeDownload() {
+        if let url = URL(string: "https://itunes.apple.com/kr/app/id1632788399") {
+            UIApplication.shared.open(url as URL, options: [:], completionHandler: nil)
+        }
+    }
 }
 
 enum NaverTerms: String{

--- a/HealthFoodMe/HealthFoodMe/Data/Network/Foundation/BaseService.swift
+++ b/HealthFoodMe/HealthFoodMe/Data/Network/Foundation/BaseService.swift
@@ -13,7 +13,7 @@ import RxSwift
 class BaseService {
     
     var disposeBag = DisposeBag()
-
+    
     @frozen enum DecodingMode {
         case model
         case message
@@ -26,7 +26,7 @@ class BaseService {
         configuration.timeoutIntervalForRequest = NetworkEnvironment.requestTimeOut
         configuration.timeoutIntervalForResource = NetworkEnvironment.resourceTimeOut
         let eventLogger = APIEventLogger()
-        session = Session(configuration: configuration, eventMonitors: [eventLogger])
+        session = Session(configuration: configuration, interceptor: eventLogger, eventMonitors: [eventLogger])
         return session
     }()
     
@@ -73,10 +73,10 @@ class BaseService {
     func judgeStatusWithEmptyReponse(by statusCode: Int?) -> NetworkResult<Any> {
         guard let statusCode = statusCode else { return .pathErr }
         switch statusCode {
-            case 200..<300: return .success(())
-            case 400..<500: return .requestErr(())
-            case 500:       return .serverErr
-            default:        return .networkFail
+        case 200..<300: return .success(())
+        case 400..<500: return .requestErr(())
+        case 500:       return .serverErr
+        default:        return .networkFail
         }
     }
     

--- a/HealthFoodMe/HealthFoodMe/Data/Network/Foundation/EventLogger.swift
+++ b/HealthFoodMe/HealthFoodMe/Data/Network/Foundation/EventLogger.swift
@@ -7,8 +7,36 @@
 
 import Alamofire
 import Foundation
+import KakaoSDKAuth
 
-class APIEventLogger: EventMonitor {
+class APIEventLogger: EventMonitor, RequestInterceptor {
+
+    private var isConnectedToInternet: Bool {
+        return NetworkReachabilityManager()!.isReachable
+    }
+    
+    private var alertAlreadySet: Bool = false
+    
+    func adapt(_ urlRequest: URLRequest, for session: Alamofire.Session, completion: @escaping (Result<URLRequest, Error>) -> Void) {
+        if !isConnectedToInternet && !alertAlreadySet {
+            self.showNetworkErrorAlert {
+                completion(.success(urlRequest))
+            }
+        } else {
+            completion(.success(urlRequest))
+        }
+    }
+    
+    private func showNetworkErrorAlert(completion: @escaping (()->Void)) {
+        alertAlreadySet = true
+        DispatchQueue.main.async {
+            let rootViewController = UIApplication.getMostTopViewController()
+            rootViewController?.makeAlert(title: "네트워크 에러", message: "네트워크 연결 상태를 확인해주세요") { _ in
+                completion()
+                self.alertAlreadySet = false
+            }
+        }
+    }
     
     let queue = DispatchQueue(label: "NetworkLogger")
     

--- a/HealthFoodMe/HealthFoodMe/Data/Network/Foundation/EventLogger.swift
+++ b/HealthFoodMe/HealthFoodMe/Data/Network/Foundation/EventLogger.swift
@@ -17,15 +17,15 @@ class APIEventLogger: EventMonitor, RequestInterceptor {
     
     private var alertAlreadySet: Bool = false
     
-    func adapt(_ urlRequest: URLRequest, for session: Alamofire.Session, completion: @escaping (Result<URLRequest, Error>) -> Void) {
-        if !isConnectedToInternet && !alertAlreadySet {
-            self.showNetworkErrorAlert {
-                completion(.success(urlRequest))
-            }
-        } else {
-            completion(.success(urlRequest))
-        }
-    }
+//    func adapt(_ urlRequest: URLRequest, for session: Alamofire.Session, completion: @escaping (Result<URLRequest, Error>) -> Void) {
+//        if !isConnectedToInternet && !alertAlreadySet {
+//            self.showNetworkErrorAlert {
+//                completion(.success(urlRequest))
+//            }
+//        } else {
+//            completion(.success(urlRequest))
+//        }
+//    }
     
     func retry(_ request: Request, for session: Session, dueTo error: Error, completion: @escaping (RetryResult) -> Void) {
         guard let pathComponents = request.request?.url?.pathComponents,

--- a/HealthFoodMe/HealthFoodMe/Global/Extension/NSBundle+.swift
+++ b/HealthFoodMe/HealthFoodMe/Global/Extension/NSBundle+.swift
@@ -1,0 +1,17 @@
+//
+//  NSBundle+.swift
+//  HealthFoodMe
+//
+//  Created by Junho Lee on 2022/09/30.
+//
+
+import Foundation
+
+public extension Bundle {
+    static var appVersion: String? {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+    }
+    static var buildVersion: String? {
+        Bundle.main.infoDictionary?["CFBundleVersion"] as? String
+    }
+}

--- a/HealthFoodMe/HealthFoodMe/Global/Extension/UI/UIApplcation+.swift
+++ b/HealthFoodMe/HealthFoodMe/Global/Extension/UI/UIApplcation+.swift
@@ -1,0 +1,40 @@
+//
+//  UIApplcation+.swift
+//  HealthFoodMe
+//
+//  Created by Junho Lee on 2022/10/01.
+//
+
+import UIKit
+
+extension UIApplication {
+    public class func getMostTopViewController(base: UIViewController? = nil) -> UIViewController? {
+
+        var baseVC: UIViewController?
+        if base != nil {
+            baseVC = base
+        }
+        else {
+            if #available(iOS 13, *) {
+                baseVC = (UIApplication.shared.connectedScenes
+                            .compactMap { $0 as? UIWindowScene }
+                            .flatMap { $0.windows }
+                            .first { $0.isKeyWindow })?.rootViewController
+            }
+            else {
+                baseVC = UIApplication.shared.keyWindow?.rootViewController
+            }
+        }
+        
+        if let naviController = baseVC as? UINavigationController {
+            return getMostTopViewController(base: naviController.visibleViewController)
+
+        } else if let tabbarController = baseVC as? UITabBarController, let selected = tabbarController.selectedViewController {
+            return getMostTopViewController(base: selected)
+
+        } else if let presented = baseVC?.presentedViewController {
+            return getMostTopViewController(base: presented)
+        }
+        return baseVC
+    }
+}

--- a/HealthFoodMe/HealthFoodMe/Global/Extension/UI/UIApplcation+.swift
+++ b/HealthFoodMe/HealthFoodMe/Global/Extension/UI/UIApplcation+.swift
@@ -9,29 +9,24 @@ import UIKit
 
 extension UIApplication {
     public class func getMostTopViewController(base: UIViewController? = nil) -> UIViewController? {
-
+        
         var baseVC: UIViewController?
         if base != nil {
             baseVC = base
         }
         else {
-            if #available(iOS 13, *) {
-                baseVC = (UIApplication.shared.connectedScenes
-                            .compactMap { $0 as? UIWindowScene }
-                            .flatMap { $0.windows }
-                            .first { $0.isKeyWindow })?.rootViewController
-            }
-            else {
-                baseVC = UIApplication.shared.keyWindow?.rootViewController
-            }
+            baseVC = (UIApplication.shared.connectedScenes
+                .compactMap { $0 as? UIWindowScene }
+                .flatMap { $0.windows }
+                .first { $0.isKeyWindow })?.rootViewController
         }
         
         if let naviController = baseVC as? UINavigationController {
             return getMostTopViewController(base: naviController.visibleViewController)
-
+            
         } else if let tabbarController = baseVC as? UITabBarController, let selected = tabbarController.selectedViewController {
             return getMostTopViewController(base: selected)
-
+            
         } else if let presented = baseVC?.presentedViewController {
             return getMostTopViewController(base: presented)
         }

--- a/HealthFoodMe/HealthFoodMe/Global/Extension/UI/UIViewController+.swift
+++ b/HealthFoodMe/HealthFoodMe/Global/Extension/UI/UIViewController+.swift
@@ -44,4 +44,27 @@ extension UIViewController {
         alertVC.modalPresentationStyle = .overCurrentContext
         present(alertVC, animated: true)
     }
+    
+    func makeAlert(alertType: AlertType = .logoutAlert,
+                   title: String?,
+                   subtitle: String?,
+                   okAction: (() -> Void)?,
+                   closeAction: (()->Void)?) {
+        
+        let alertVC = ModuleFactory.resolve().makeHelfmeAlertVC(type: alertType)
+        
+        alertVC.alertType = alertType
+        if let title = title {
+            alertVC.alertTitle = title
+        }
+        if let subtitle = subtitle {
+            alertVC.alertContent = subtitle
+        }
+        alertVC.okAction = okAction
+        alertVC.closeAction = closeAction
+        
+        alertVC.modalTransitionStyle = .crossDissolve
+        alertVC.modalPresentationStyle = .overCurrentContext
+        present(alertVC, animated: true)
+    }
 }

--- a/HealthFoodMe/HealthFoodMe/Presentation/Common/HelfmeAlerts/VC/HelfmeAlertVC.swift
+++ b/HealthFoodMe/HealthFoodMe/Presentation/Common/HelfmeAlerts/VC/HelfmeAlertVC.swift
@@ -24,6 +24,7 @@ final class HelfmeAlertVC: UIViewController {
     var alertTitle: String?
     var alertContent: String?
     var okAction: (() -> Void)?
+    var closeAction: (()->Void)?
     
     // MARK: - UI Components
     
@@ -134,5 +135,6 @@ extension HelfmeAlertVC: AlertDelegate {
     
     func alertDismiss() {
         dismiss(animated: true)
+        self.closeAction?()
     }
 }

--- a/HealthFoodMe/HealthFoodMe/Presentation/Splash/SplashScene/VC/SplashVC.swift
+++ b/HealthFoodMe/HealthFoodMe/Presentation/Splash/SplashScene/VC/SplashVC.swift
@@ -93,9 +93,9 @@ extension SplashVC {
                 let versionCompare = appVersion.compare(versionStandard, options: .numeric)
                 
                 switch (versionCompare, needUpdate) {
-                case (_, true):
+                case (.orderedAscending, true):
                     self.showForceUpdateAlert()
-                case (.orderedAscending, _):
+                case (.orderedAscending, false):
                     self.showRecommendUpdateAlert()
                 default:
                     self.startFlow()

--- a/HealthFoodMe/HealthFoodMe/Presentation/Splash/SplashScene/VC/SplashVC.swift
+++ b/HealthFoodMe/HealthFoodMe/Presentation/Splash/SplashScene/VC/SplashVC.swift
@@ -112,7 +112,7 @@ extension SplashVC {
             self.makeAlert(title: "최신 버전으로 업데이트 해야합니다",
                            subtitle: "현재 다운로드된 버전이 너무 낮아 앱이 정상 작동하지 않을 수 있습니다.",
                            okAction: {
-                
+                URLSchemeManager.shared.loadHelfMeDownload()
             }) {
                 self.fetchNeedsUpdate()
             }
@@ -124,7 +124,7 @@ extension SplashVC {
             self.makeAlert(title: "최신 버전으로 업데이트 하시겠습니까?",
                            subtitle: "최신 버전(\(self.latestAppVersion ?? ""))에서 최적의 사용 환경을 보장할 수 있습니다.",
                            okAction: {
-                
+                URLSchemeManager.shared.loadHelfMeDownload()
             }) {
                 self.startFlow()
             }

--- a/HealthFoodMe/HealthFoodMe/Presentation/Splash/SplashScene/VC/SplashVC.swift
+++ b/HealthFoodMe/HealthFoodMe/Presentation/Splash/SplashScene/VC/SplashVC.swift
@@ -8,12 +8,22 @@
 import UIKit
 
 import Lottie
+import FirebaseRemoteConfig
 
 class SplashVC: UIViewController {
     
     // MARK: - Properties
     
     let userManager = UserManager.shared
+    lazy var remoteConfig = {
+        let config = RemoteConfig.remoteConfig()
+        let settings = RemoteConfigSettings()
+        settings.minimumFetchInterval = 0
+        config.configSettings = settings
+        config.setDefaults(fromPlist: "remote_config_defaults")
+        return config
+    }()
+    private var latestAppVersion: String?
     
     // MARK: - UI Components
     
@@ -66,12 +76,66 @@ extension SplashVC {
             UIView.animate(withDuration: 1) {
                 self.animationView.alpha = 0
             } completion: { _ in
-                if self.userManager.isLogin == true {
-                    self.reissuanceToken()
-                } else {
-                    self.presentSocialLoginVC()
-                }
+                self.fetchNeedsUpdate()
             }
+        }
+    }
+    
+    private func fetchNeedsUpdate() {
+        self.remoteConfig.fetchAndActivate { (status, error) -> Void in
+            switch status {
+            case .successFetchedFromRemote, .successUsingPreFetchedData:
+                let needUpdate = self.remoteConfig.configValue(forKey: "forceUpdate").boolValue
+                guard let appVersion = Bundle.appVersion,
+                      let versionStandard = self.remoteConfig.configValue(forKey: "versionStandard").stringValue else { return }
+                
+                self.latestAppVersion = versionStandard
+                let versionCompare = appVersion.compare(versionStandard, options: .numeric)
+                
+                switch (versionCompare, needUpdate) {
+                case (_, true):
+                    self.showForceUpdateAlert()
+                case (.orderedAscending, _):
+                    self.showRecommendUpdateAlert()
+                default:
+                    self.startFlow()
+                }
+            default:
+                print("Config not fetched")
+                print("Error: \(error?.localizedDescription ?? "No error available.")")
+            }
+        }
+    }
+    
+    private func showForceUpdateAlert() {
+        DispatchQueue.main.async {
+            self.makeAlert(title: "최신 버전으로 업데이트 해야합니다",
+                           subtitle: "현재 다운로드된 버전이 너무 낮아 앱이 정상 작동하지 않을 수 있습니다.",
+                           okAction: {
+                
+            }) {
+                self.fetchNeedsUpdate()
+            }
+        }
+    }
+    
+    private func showRecommendUpdateAlert() {
+        DispatchQueue.main.async {
+            self.makeAlert(title: "최신 버전으로 업데이트 하시겠습니까?",
+                           subtitle: "최신 버전(\(self.latestAppVersion ?? ""))에서 최적의 사용 환경을 보장할 수 있습니다.",
+                           okAction: {
+                
+            }) {
+                self.startFlow()
+            }
+        }
+    }
+    
+    private func startFlow() {
+        if self.userManager.isLogin == true {
+            self.reissuanceToken()
+        } else {
+            self.presentSocialLoginVC()
         }
     }
 }

--- a/HealthFoodMe/HealthFoodMe/remote_config_defaults.plist
+++ b/HealthFoodMe/HealthFoodMe/remote_config_defaults.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>forceUpdate</key>
+  <string>true</string>
+  <key>versionStandard</key>
+  <string>1.0.1</string>
+</dict>
+</plist>


### PR DESCRIPTION
## 🔥 *Pull requests*

⛳️ **작업한 브랜치**
- feature/#224

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
### 긴급 상황을 위한 강제 업데이트 및 업데이트 권장 플로우 구현했습니다.

FirebaseRemoteConfig를 이용했습니다

### 네트워크 에러 팝업 및 토큰 재발급 로직을 구현했습니다.

Alamofire의 RequestInterceptor를 사용했습니다.

### 요약

* 업데이트 팝업 플로우
  - standardVersion보다 낮은 경우에만 업데이트 팝업 띄움
  - force가 true이면 강제 업데이트 팝업, false이면 권장 업데이트 팝업

* 네트워크 에러 플로우
  - alamofire의 interceptor를 통해 request를 가로채서 네트워크 상태가 false인 경우에 UIApplication의 topViewController에 alert를 띄우고 확인 버튼을 누르면 다시 통신을 진행함.

* 토큰 재발급 플로우
  - request가 실패했을 때, status 401(토큰 만료)이며, path가 token을 포함하고 있지 않을 때(토큰 재발급에서 토큰 재발급을 또 호출하는 것을 막기 위함) 토큰을 재발급해보고 이것마저 실패하면 retry를 다시 하지 않음.

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
Firebase Console에서 아래 변수들의 값을 바꾸면 앱에서 통신을 진행하여 업데이트 필요 여부를 판단합니다. 일단 구현만 해놓고, 기획 분들과 협의하여 진행해야 할 것 같습니다.

<img width="1134" alt="image" src="https://user-images.githubusercontent.com/77208067/193238539-f61caf8a-07a7-41fc-b5c5-753c09c8115e.png">


### 강제 업데이트 및 권장 업데이트 팝업

https://user-images.githubusercontent.com/77208067/193238911-cc6383c7-553f-462e-aba7-4acf5ff22bca.mp4

https://user-images.githubusercontent.com/77208067/193238923-0a9286a1-0388-4d0f-9979-f30ffef8f418.mp4

### 네트워크 에러 팝업

https://user-images.githubusercontent.com/77208067/193398455-d3401a3a-b5da-4952-820e-9216df5cf477.mp4

## 📟 관련 이슈
- Resolved: #224 
