### PR TITLE
[Fix] #314 - 검색 관련 3차 QA 반영

### DIFF
--- a/HealthFoodMe/HealthFoodMe/Presentation/Search/SearchScene/VC/SearchResultVC.swift
+++ b/HealthFoodMe/HealthFoodMe/Presentation/Search/SearchScene/VC/SearchResultVC.swift
@@ -46,7 +46,7 @@ final class SearchResultVC: UIViewController {
         return view
     }()
     
-    private lazy var searchTextField: UITextField = {
+    lazy var searchTextField: UITextField = {
         let tf = UITextField()
         tf.leftViewMode = .always
         tf.rightViewMode = .always

--- a/HealthFoodMe/HealthFoodMe/Presentation/Search/SearchScene/VC/SearchVC.swift
+++ b/HealthFoodMe/HealthFoodMe/Presentation/Search/SearchScene/VC/SearchVC.swift
@@ -236,7 +236,19 @@ extension SearchVC {
         } else {
             requestRestaurantSearchResult(searchRequest: SearchRequestEntity(longitude: lng,
                                                                              latitude: lat,
-                                                                             keyword: keyword), fromRecent: fromRecent)
+                                                                             keyword: keyword), fromRecent: fromRecent) {
+                if self.searchResultList.count == 1 {
+                    self.searchTextField.text = self.searchResultList[0].storeName
+                    let searchResultVC = ModuleFactory.resolve().makeSearchResultVC()
+                    searchResultVC.searchTextField.text = self.searchResultList[0].storeName
+                    searchResultVC.delegate = self
+                    searchResultVC.fromSearchType = .searchRecent
+                    searchResultVC.fromSearchCellInitial = self.searchResultList[0].id
+                    searchResultVC.searchContent = self.searchResultList[0].storeName
+                    searchResultVC.searchResultList = self.searchResultList
+                    self.navigationController?.pushViewController(searchResultVC, animated: false)
+                }
+            }
         }
     }
     
@@ -566,7 +578,7 @@ extension SearchVC {
         }
     }
     
-    private func requestRestaurantSearchResult(searchRequest: SearchRequestEntity, fromRecent: Bool) {
+    private func requestRestaurantSearchResult(searchRequest: SearchRequestEntity, fromRecent: Bool, completion: @escaping(() -> Void)) {
         RestaurantService.shared.requestRestaurantSearchResult(searchRequest: SearchRequestEntity(longitude: searchRequest.longitude,
                                                                                                   latitude: searchRequest.latitude,
                                                                                                   keyword: searchRequest.keyword)) { networkResult in
@@ -582,6 +594,7 @@ extension SearchVC {
                     }
                     self.searchResultList = self.searchResultList.sorted(by: { $0.distance < $1.distance })
                     self.isSearchResult(fromRecent: fromRecent, isCategory: false)
+                    completion()
                 }
             default:
                 break;

--- a/HealthFoodMe/HealthFoodMe/Presentation/Search/SearchScene/VC/SearchVC.swift
+++ b/HealthFoodMe/HealthFoodMe/Presentation/Search/SearchScene/VC/SearchVC.swift
@@ -378,6 +378,8 @@ extension SearchVC {
             if let text = searchTextField.text {
                 if !searchList.isEmpty && !isCategory {
                     addSearchRecent(title: text, isCategory: false)
+                } else {
+                    addSearchRecent(title: text, isCategory: true)
                 }
             }
             searchTableView.tableHeaderView = searchHeaderView
@@ -420,7 +422,12 @@ extension SearchVC: UITextFieldDelegate {
         if let text = searchTextField.text {
             let searchContent = text.trimmingCharacters(in: .whitespaces)
             if !searchContent.isEmpty {
-                fetchSearchResultData(keyword: searchContent, fromRecent: false, isCategory: false)
+                if  !searchList.isEmpty && searchList[0].isCategory && searchContent == searchList[0].title {
+                    category = searchContent
+                    fetchSearchResultData(keyword: searchContent, fromRecent: false, isCategory: true)
+                } else {
+                    fetchSearchResultData(keyword: searchContent, fromRecent: false, isCategory: false)
+                }
             }
         }
         return true


### PR DESCRIPTION
## 🔥 *Pull requests*

⛳️ **작업한 브랜치**
- feature/#이슈번호

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->

- 카테고리 검색 후 return 눌렀을 때 해당 카테고리 명으로 뜨도록 수정
- 검색 결과 식당 목록 1개인 경우 핀 선택된 채 넘어가도록 수정

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

정확히 맞는 로직인지 확인 안되었지만 일단 날릴게용
나중에 수정하겠슴다 ~!

## 📸 스크린샷

## 📟 관련 이슈
- Resolved: #314 
