### PR TITLE
[fix] 외식대처법 화면 짤리는 부분을 스크롤 방식으로 수정

### DIFF
--- a/HealthFoodMe/HealthFoodMe/Global/Literals/BaseNotiList.swift
+++ b/HealthFoodMe/HealthFoodMe/Global/Literals/BaseNotiList.swift
@@ -16,6 +16,7 @@ enum BaseNotiList: String {
   case reviewPhotoClicked
   case menuPhotoClicked
   case copingPanGestureEnabled
+  case copingTableViewScrollTop
   
   static func makeNotiName(list: BaseNotiList) -> NSNotification.Name {
     return Notification.Name(String(describing: list))

--- a/HealthFoodMe/HealthFoodMe/Presentation/Detail/CopingTabScene/Cell/ContentTVC.swift
+++ b/HealthFoodMe/HealthFoodMe/Presentation/Detail/CopingTabScene/Cell/ContentTVC.swift
@@ -61,7 +61,6 @@ extension ContentTVC {
     }
     
     private func setLayout() {
-        let screenWidth = UIScreen.main.bounds.width
         self.contentView.addSubviews(contentStackView)
         
         checkImageView.snp.makeConstraints {  make in
@@ -69,14 +68,14 @@ extension ContentTVC {
         }
         
         contentLabel.snp.makeConstraints { make in
-            make.width.equalTo(screenWidth - 170)
             make.trailing.equalTo(contentStackView.snp.trailing)
         }
         
         contentStackView.snp.makeConstraints { make in
             make.top.equalToSuperview().offset(9)
             make.bottom.equalToSuperview().inset(9)
-            make.centerX.equalToSuperview()
+            make.leading.equalToSuperview().offset(46)
+            make.trailing.equalToSuperview().inset(46)
         }
     }
     

--- a/HealthFoodMe/HealthFoodMe/Presentation/Detail/CopingTabScene/Cell/CopingTVC.swift
+++ b/HealthFoodMe/HealthFoodMe/Presentation/Detail/CopingTabScene/Cell/CopingTVC.swift
@@ -60,10 +60,11 @@ class CopingTVC: UITableViewCell, UITableViewRegisterable {
         tv.sectionFooterHeight = 0
         tv.allowsSelection = false
         tv.isScrollEnabled = false
-        tv.bounces = true
+        tv.bounces = false
         tv.layer.borderColor = UIColor.helfmeLineGray.cgColor
         tv.layer.borderWidth = 0.5
         tv.layer.cornerRadius = 15
+        tv.automaticallyAdjustsScrollIndicatorInsets = false
         if #available(iOS 15, *) {
             tv.sectionHeaderTopPadding = 0
         }
@@ -192,7 +193,7 @@ extension CopingTVC {
 extension CopingTVC: UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return tableView.rowHeight
+        return UITableView.automaticDimension
     }
     
     func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
@@ -220,14 +221,11 @@ extension CopingTVC: UITableViewDelegate {
         }
     }
     
-    func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        
-        if (self.lastPosY > scrollView.contentOffset.y) && scrollView.contentOffset.y < 10
-            || self.lastPosY < 0{
+    func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
+
+        if scrollView.contentOffset.y < 15 {
             postObserverAction(.copingTableViewScrollTop)
         }
-            
-        lastPosY = scrollView.contentOffset.y
         
     }
 }

--- a/HealthFoodMe/HealthFoodMe/Presentation/Detail/CopingTabScene/VC/CopingTabVC.swift
+++ b/HealthFoodMe/HealthFoodMe/Presentation/Detail/CopingTabScene/VC/CopingTabVC.swift
@@ -40,6 +40,7 @@ class CopingTabVC: UIViewController {
         tv.separatorStyle = .none
         tv.backgroundColor = .white
         tv.clipsToBounds = true
+        tv.isScrollEnabled = false
         tv.sectionFooterHeight = 0
         tv.allowsSelection = false
         tv.bounces = false
@@ -70,9 +71,10 @@ extension CopingTabVC {
         view.addSubviews(copingTabTableView)
         
         copingTabTableView.snp.makeConstraints { make in
-            make.top.bottom.equalTo(view.safeAreaLayoutGuide)
+            make.top.equalTo(view.safeAreaLayoutGuide)
             make.leading.equalToSuperview().offset(20)
             make.trailing.equalToSuperview().inset(20)
+            make.bottom.equalToSuperview()
         }
     }
     
@@ -91,6 +93,11 @@ extension CopingTabVC {
             if let state = noti.object as? Bool {
                 self.panGesture.isEnabled = state
             }
+        }
+        
+        addObserverAction(.copingTableViewScrollTop) { _ in
+            self.swipeDelegate?.swipeToDismiss()
+            self.delegate?.childViewScrollDidEnd(type: .coping)
         }
     }
     
@@ -125,6 +132,49 @@ extension CopingTabVC {
             }).disposed(by: disposeBag)
         
     }
+    
+    private func calculateContentCellHeight() -> CGFloat {
+
+        let window = UIApplication.shared.windows.first { $0.isKeyWindow }
+        let statusBarManager = window?.windowScene?.statusBarManager
+        let statusBarView = UIView(frame: statusBarManager?.statusBarFrame ?? CGRect.zero)
+        
+        let statusBarHeight = statusBarView.frame.height
+        let navigationBarHeight = self.navigationController?.navigationBar.frame.height ?? 0
+        
+        let categoryCellHeight: CGFloat = (copingDataList.count == 1 ? 20 : 72)
+        let menuCellHeight: CGFloat = 44
+        
+        let screenHeight = UIScreen.main.bounds.height
+        let topElementsHeight = statusBarHeight + navigationBarHeight + categoryCellHeight + menuCellHeight
+        
+        let estimatedMaximumHeight = screenHeight - topElementsHeight - 48
+        let tableViewHeight = copingTableViewHeight()
+        print("HEIGHT",estimatedMaximumHeight,tableViewHeight)
+        return min(estimatedMaximumHeight,tableViewHeight)
+    }
+    
+    private func copingTableViewHeight() -> CGFloat {
+        guard !copingDataList.isEmpty,
+              copingDataList.count > currentIdx else { return 1000 }
+        
+        let headerHeight: CGFloat = 126
+        let bottomMargin: CGFloat = 52
+        
+        let cellCalculator = CopingCellCalculator.shared
+        var cellHeight: CGFloat {
+            let recommendListHeight = cellCalculator.calculateCellHeight(tipList: copingDataList[currentIdx].recommend)
+            let eatingListHeight = cellCalculator.calculateCellHeight(tipList: copingDataList[currentIdx].tip)
+            return recommendListHeight + eatingListHeight
+        }
+        
+        var tableViewHeight: CGFloat {
+            let calculatedHeight: CGFloat = headerHeight * 2 + cellHeight + bottomMargin * 2
+            return calculatedHeight
+        }
+        
+        return tableViewHeight
+    }
 }
 
 // MARK: - Network
@@ -153,8 +203,16 @@ extension CopingTabVC: UITableViewDelegate {
         if indexPath.section == 0 {
             return copingDataList.count == 1 ? 20 : 72
         } else {
-            return UITableView.automaticDimension
+            return calculateContentCellHeight()
         }
+    }
+    
+    func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        return UIView()
+    }
+    
+    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        return 0
     }
 }
 

--- a/HealthFoodMe/HealthFoodMe/Presentation/Detail/CopingTabScene/VC/CopingTabVC.swift
+++ b/HealthFoodMe/HealthFoodMe/Presentation/Detail/CopingTabScene/VC/CopingTabVC.swift
@@ -148,10 +148,14 @@ extension CopingTabVC {
         let screenHeight = UIScreen.main.bounds.height
         let topElementsHeight = statusBarHeight + navigationBarHeight + categoryCellHeight + menuCellHeight
         
-        let estimatedMaximumHeight = screenHeight - topElementsHeight - 48
+        let estimatedMaximumHeight = screenHeight - topElementsHeight - 68
         let tableViewHeight = copingTableViewHeight()
-        print("HEIGHT",estimatedMaximumHeight,tableViewHeight)
-        return min(estimatedMaximumHeight,tableViewHeight)
+        print("HEIEHE",estimatedMaximumHeight,tableViewHeight)
+        if estimatedMaximumHeight > tableViewHeight {
+            return tableViewHeight
+        } else {
+            return estimatedMaximumHeight
+        }
     }
     
     private func copingTableViewHeight() -> CGFloat {

--- a/HealthFoodMe/HealthFoodMe/Presentation/Detail/MainDetailScene/VC/MainDetailVC.swift
+++ b/HealthFoodMe/HealthFoodMe/Presentation/Detail/MainDetailScene/VC/MainDetailVC.swift
@@ -323,6 +323,7 @@ extension MainDetailVC: UITableViewDelegate {
             postObserverAction(.copingPanGestureEnabled,object: true)
             copingTapPanGestureDisabled = false
         }
+
         self.lastContentOffset = scrollView.contentOffset.y
     }
 }
@@ -391,12 +392,15 @@ extension MainDetailVC: UITableViewDataSource {
                     if ratio < 1/3{
                         self.menuCase = .menu
                         self.menuTabVC.topScrollAnimationNotFinished = true
+                        self.mainTableView.isScrollEnabled = true
                     } else if ratio < 2/3 {
                         self.menuCase = .coping
                         self.copingTabVC.topScrollAnimationNotFinished = true
+                        self.mainTableView.isScrollEnabled = false
                     } else {
                         self.menuCase = .review
                         self.reviewTabVC.topScrollAnimationNotFinished = true
+                        self.mainTableView.isScrollEnabled = true
                     }
                     
                     if ratio == 0 {
@@ -458,10 +462,10 @@ extension MainDetailVC: ScrollDeliveryDelegate {
         self.mainTableView.scrollToRow(at: IndexPath(row: 0, section: 0), at: .top, animated: true)
         setNavigationTitle(isShown: false)
         switch(type) {
-        case .menu:     menuTabVC.topScrollAnimationNotFinished = true
-        case .coping:   copingTabVC.topScrollAnimationNotFinished = true
-        case .review:
-            reviewTabVC.topScrollAnimationNotFinished = true
+            case .menu:     menuTabVC.topScrollAnimationNotFinished = true
+            case .coping:   copingTabVC.topScrollAnimationNotFinished = true
+            case .review:
+                reviewTabVC.topScrollAnimationNotFinished = true
         }
     }
     
@@ -479,21 +483,21 @@ extension MainDetailVC: ScrollDeliveryDelegate {
     func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
         if scrollView.contentOffset.y < 10 {
             switch(menuCase) {
-            case .menu: menuTabVC.topScrollAnimationNotFinished = true
-            case .coping: copingTabVC.topScrollAnimationNotFinished = true
-            case .review: reviewTabVC.topScrollAnimationNotFinished = true
+                case .menu: menuTabVC.topScrollAnimationNotFinished = true
+                case .coping: copingTabVC.topScrollAnimationNotFinished = true
+                case .review: reviewTabVC.topScrollAnimationNotFinished = true
             }
         }
         
         if scrollView.contentOffset.y > 50 {
             switch(menuCase) {
-            case .menu: menuTabVC.topScrollAnimationNotFinished = false
-            case .coping: copingTabVC.topScrollAnimationNotFinished = false
-            case .review: reviewTabVC.topScrollAnimationNotFinished = false
+                case .menu: menuTabVC.topScrollAnimationNotFinished = false
+                case .coping: copingTabVC.topScrollAnimationNotFinished = false
+                case .review: reviewTabVC.topScrollAnimationNotFinished = false
             }
         }
     }
-}
+    }
 
 extension MainDetailVC: CopingGestureDelegate {
     func downPanGestureSwipe(panGesture: ControlEvent<UIPanGestureRecognizer>.Element) {


### PR DESCRIPTION
## 🔥 *Pull requests*

⛳️ **작업한 브랜치**
- feature/#315

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 외식대처법 스크롤 수정

## 🚨 참고 사항
가장 아랫단이 UIViewController여서, 내부의 컨텐츠 크기를 늘리는 방식이 불가능한 형태라, 
지금 있는 구조에서 내부 테이블 뷰에서 스크롤만 될 수 있도록 수정했습니다 ...
기디쪽에서 수정 요청 들어오면 생각좀 해볼게요... 최소 2일은 걸릴것 같은 대 작업이 예상됩니다..

## 📸 스크린샷

https://user-images.githubusercontent.com/60260284/194338469-3213e31a-b83c-41c2-8c51-b0f4d787044c.mov


